### PR TITLE
do not display empty slots in the past games

### DIFF
--- a/games/api/views.py
+++ b/games/api/views.py
@@ -90,7 +90,7 @@ class FutureGameSessionViewSet(GameSessionViewSet):
 
 
 class PastGameSessionViewSet(GameSessionViewSet):
-    queryset = GameSession.games.past()
+    queryset = GameSession.games.past().exclude(adventure=None)
 
 
 class GameSessionBookViewSet(mixins.UpdateModelMixin,


### PR DESCRIPTION
Filters out empty games from the past games view.

Closes #68 