### PR TITLE
JWT token auth rewritten and added refresh

### DIFF
--- a/front/src/api.js
+++ b/front/src/api.js
@@ -1,0 +1,35 @@
+import {API_HOSTNAME} from "./config";
+
+
+export default class Api {
+  auth;
+
+  constructor(auth){
+    this.auth = auth;
+  }
+
+  get(url){
+    return this.auth.getAxiosInstance().then(instance => instance.get(`${API_HOSTNAME}${url}`));
+  }
+
+  post(url, data){
+    return this.auth.getAxiosInstance().then(instance => instance.post(`${API_HOSTNAME}${url}`, data));
+  }
+
+  put(url, data){
+    return this.auth.getAxiosInstance().then(instance => instance.put(`${API_HOSTNAME}${url}`, data));
+  }
+
+
+  fetchData(name){
+    return this.get(`/${name}/`).then(response => response.data);
+  }
+
+  getData(name, id){
+    return this.get(`/${name}/${id}/`).then(response => response.data);
+  }
+
+  putData(name, id, data){
+    return this.put(`/${name}/${id}/`, data).then(response => response.data);
+  }
+}

--- a/front/src/common/Login.js
+++ b/front/src/common/Login.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import classNames from 'classnames';
 import {inject, observer} from "mobx-react";
-import {Redirect} from "react-router-dom";
 import Grid from '@material-ui/core/Grid';
 import withStyles from '@material-ui/core/styles/withStyles';
 import Button from "@material-ui/core/Button/Button";
@@ -40,7 +39,6 @@ const styles = (theme) => ({
 @inject('portalStore') @observer
 class Login extends React.Component {
   state = {
-    redirectToReferrer: false,
     isSigning: false,
     email: '',
     password: '',
@@ -54,14 +52,15 @@ class Login extends React.Component {
     this.setState({
       isSigning: true
     });
-    this.props.portalStore.login(this.state.email.toLowerCase, this.state.password)
+    this.props.portalStore.login(this.state.email.toLowerCase(), this.state.password)
       .then(() => {
         this.setState(() => ({
-          redirectToReferrer: true,
           email: '',
           password: '',
           isSigning: false
-        }))
+        }));
+        const { from } = this.props.location.state || { from: { pathname: '/' } };
+        this.props.history.push(from);
       }).catch((error) => {
         if(error.response.status === 400){
           this.setState({
@@ -85,13 +84,6 @@ class Login extends React.Component {
   };
 
   render() {
-    const { from } = this.props.location.state || { from: { pathname: '/' } };
-    const { redirectToReferrer } = this.state;
-
-    if (redirectToReferrer === true) {
-      return <Redirect to={from} />
-    }
-
     const {classes} = this.props;
 
     return (

--- a/front/src/common/Register.js
+++ b/front/src/common/Register.js
@@ -106,7 +106,7 @@ export default class Register extends React.Component {
         nickname: this.state.nickname,
         dci: this.state.dci ? this.state.dci : null,
         user: {
-          email: this.state.email.toLowerCase,
+          email: this.state.email.toLowerCase(),
           password: this.state.password,
           first_name: this.state.first_name,
           last_name: this.state.last_name,

--- a/front/src/constants.js
+++ b/front/src/constants.js
@@ -1,2 +1,8 @@
 
-export const JWT_TOKEN = 'jwt-token';
+export const JWT_TOKEN = 'jwt';
+export const JWT_TOKEN_IAT = 'jwt_iat';
+export const JWT_TOKEN_ORIG_IAT = 'jwt_orig_iat';
+
+export const TOKEN_REFRESH_RATE = 10 * 60 * 1000; // token should be refreshed after 10 minutes
+export const TOKEN_EXPIRATION_DELTA =  48 * 3600 * 1000; // token will expire after 48 hours
+export const TOKEN_REFRESH_EXPIRATION = 7 * 24 * 3600 * 1000; // token can be refreshed for 7 days

--- a/front/src/pages/Games.js
+++ b/front/src/pages/Games.js
@@ -199,7 +199,7 @@ export default class Games extends React.Component {
       <Fragment>
         <Grid container spacing={8} className={classes.cardsRoot}>
           {list.map(game => (
-            <Fragment>
+            <Fragment key={`game-${game.id}`}>
               {(displayEmpty || game.adventure) ? (
                 <Grid item xs={12} md={6} lg={4} key={`game-list-card-${game.id}`}>
                   <GameCard game={game}/>

--- a/front/src/pages/PasswordReset.js
+++ b/front/src/pages/PasswordReset.js
@@ -83,7 +83,7 @@ export default class PasswordReset extends React.Component {
               </Grid>
             </Grid>
           ): (
-          <form className={classes.container} noValidate autoComplete="off" onSubmit={this.login}>
+          <form className={classes.container} noValidate autoComplete="off">
             <Grid container spacing={24}>
               <Grid item xs={12}>
                 <h1>Reset your password</h1>

--- a/front/src/pages/Profiles.js
+++ b/front/src/pages/Profiles.js
@@ -59,7 +59,7 @@ class Profiles extends React.Component {
 
   profiles_list() {
     if(this.state.profiles){
-      return this.state.profiles.map(profile => <ProfileListItem profile={profile} history={this.props.history}/>)
+      return this.state.profiles.map(profile => <ProfileListItem key={`profile-${profile.id}`} profile={profile} history={this.props.history}/>)
     }
   }
 

--- a/front/src/store.js
+++ b/front/src/store.js
@@ -6,10 +6,12 @@ import TokenAuthorizationStore from "./stores/TokenAuthorizationStore";
 import {AxiosInstance as axiosInstance} from "axios";
 import UserStore from "./stores/UserStore";
 import NavigationStore from "./stores/NavigationStore";
+import Api from "./api";
 
 
 export class PortalStore {
   @observable auth = new TokenAuthorizationStore(this);
+  @observable api = new Api(this.auth);
   @observable currentUser = null;
   @observable navigationStore = new NavigationStore(this);
   @observable games = new GamesStore(this);
@@ -59,11 +61,6 @@ export class PortalStore {
   }
 
   @action.bound
-  get(url){
-    return this.getAxiosInstance().then(instance => instance.get(`${API_HOSTNAME}${url}`));
-  }
-
-  @action.bound
   fetchCurrentUser(){
     if(this.isAuthenticated()){
       this.currentUser = new UserStore(this);
@@ -87,62 +84,47 @@ export class PortalStore {
   };
 
   @action.bound
-  fetchData(name){
-    return this.get(`/${name}/`).then(response => response.data);
-  }
-
-  @action.bound
-  getData(name, id){
-    return this.get(`/${name}/${id}/`).then(response => response.data);
-  }
-
-  @action.bound
-  putData(name, id, data){
-    return this.getAxiosInstance().then(instance => instance.put(`${API_HOSTNAME}/${name}/${id}/`, data));
-  }
-
-  @action.bound
   fetchProfiles() {
-    return this.fetchData('profiles')
+    return this.api.fetchData('profiles')
   }
 
   @action.bound
   getProfile(id){
-    return this.getData('profiles', id);
+    return this.api.getData('profiles', id);
   }
 
   @action.bound
   fetchCharacters(){
-    return this.fetchData('characters');
+    return this.api.fetchData('characters');
   }
 
   @action.bound
   fetchProfileCharacters(owner){
-    return this.get(`/characters/?owner=${owner}`).then(response => response.data);
+    return this.api.get(`/characters/?owner=${owner}`).then(response => response.data);
   }
 
   @action.bound
   getCharacter(id){
-    return this.get(`/characters/${id}/`).then(response => response.data);
+    return this.api.get(`/characters/${id}/`).then(response => response.data);
   }
 
   @action.bound
   searchCharacters(search_term){
-    return this.get(`/characters/?search=${search_term}`).then(response => response.data);
+    return this.api.get(`/characters/?search=${search_term}`).then(response => response.data);
   }
 
   @action.bound
   createCharacter(data){
-    return this.getAxiosInstance().then(instance => instance.post(`${API_HOSTNAME}/characters/`, data).then(response => {
+    return this.api.post(`/characters/`, data).then(response => {
       if(response.status === 201){
         this.currentUser.charactersCount++;
       }
-    }));
+    });
   }
 
   @action.bound
   saveCharacter(id, data){
-    return this.getAxiosInstance().then(instance => instance.put(`${API_HOSTNAME}/characters/${id}/`, data));
+    return this.api.put(`/characters/${id}/`, data);
   }
 }
 

--- a/front/src/store.js
+++ b/front/src/store.js
@@ -47,7 +47,6 @@ export class PortalStore {
     return new Promise((resolve, reject) => {
       this.auth.autologin().then(response => {
         if(response !== null){
-          console.log('token refreshed...');
           this.currentUser = new UserStore(this);
           this.currentUser.fetchData()
             .then(() => resolve(response), () => { reject(response) })

--- a/front/src/store.js
+++ b/front/src/store.js
@@ -1,222 +1,66 @@
-import {observable, action, computed, reaction} from 'mobx';
-import axios from 'axios';
-import Cookies from 'js-cookie';
+import {action, observable} from 'mobx';
 import {API_HOSTNAME} from "./config";
-import {
-  JWT_TOKEN,
-  JWT_TOKEN_IAT,
-  JWT_TOKEN_ORIG_IAT,
-  TOKEN_EXPIRATION_DELTA,
-  TOKEN_REFRESH_EXPIRATION,
-  TOKEN_REFRESH_RATE
-} from "./constants";
 import GamesStore from "./stores/GamesStore";
 import AdventuresStore from "./stores/AdventuresStore";
-
-
-const csrftoken = Cookies.get('csrftoken');
-
-
-export const axiosInstance = axios.create({
-  headers: {
-    'X-CSRFToken': csrftoken,
-  }
-});
+import TokenAuthorizationStore from "./stores/TokenAuthorizationStore";
+import {AxiosInstance as axiosInstance} from "axios";
+import UserStore from "./stores/UserStore";
+import NavigationStore from "./stores/NavigationStore";
 
 
 export class PortalStore {
+  @observable auth = new TokenAuthorizationStore(this);
   @observable currentUser = null;
-  @observable token = window.localStorage.getItem(JWT_TOKEN);
-  @observable token_iat = window.localStorage.getItem(JWT_TOKEN_IAT);
-  @observable token_original_iat = window.localStorage.getItem('jwt_orig_iat');
-  @observable authenticated = false;
   @observable navigationStore = new NavigationStore(this);
   @observable games = new GamesStore(this);
   @observable adventures = new AdventuresStore(this);
 
-  constructor() {
-    reaction(
-      () => this.token,
-      token => {
-        if (token){
-          window.localStorage.setItem(JWT_TOKEN, token);
-        } else {
-          window.localStorage.removeItem(JWT_TOKEN);
-        }
-      }
-    );
-
-    reaction(
-      () => this.token_iat,
-      token_iat => {
-        if (token_iat) {
-          window.localStorage.setItem(JWT_TOKEN_IAT, token_iat);
-        } else {
-          window.localStorage.removeItem(JWT_TOKEN_IAT);
-        }
-      }
-    );
-
-    reaction(
-      () => this.token_original_iat,
-      token_iat => {
-        if (token_iat) {
-          window.localStorage.setItem(JWT_TOKEN_ORIG_IAT, token_iat);
-        } else {
-          window.localStorage.removeItem(JWT_TOKEN_ORIG_IAT);
-        }
-      }
-    );
-  }
-
-  createAxiosInstance() {
-    const instance = axios.create({
-      headers: {
-        'X-CSRFToken': Cookies.get('csrftoken'),
-        'Authorization': `JWT ${this.token}`
-      }
-    });
-
-    instance.interceptors.response.use(response => {
-       return response;
-    }, error => {
-      if (error.response.status === 401) {
-        console.log('Tokens have expired! Need to sign in again');
-        this.signOut();
-        window.location.reload();
-      }
-      return error;
-    });
-
-    return instance;
+  @action
+  isAuthenticated(){
+    return this.auth.isAuthenticated() && this.currentUser && this.currentUser.profileID !== undefined;
   }
 
   getAxiosInstance(){
-    return new Promise((resolve) => {
-      console.log('loading...', this.token_iat);
-      if(this.tokenShouldRefresh && this.tokenValidIat){
-        console.log('refreshing token!', this.token_iat);
+    return this.auth.getAxiosInstance();
+  }
 
-        this.refreshToken().then(() => {
-          resolve(this.createAxiosInstance());
-        }).catch(e => {
-          console.log('Looks like there was an issue with retrieving token data. Resetting state to login.', e);
-          this.signOut();
-          window.location.reload();
-        });
-      }
-      else {
-        if (!this.tokenValidOrigIat) {
-          console.log('Expired refresh! Cannot get any new token until user signs in');
-          this.signOut();
-          window.location.reload();
+  @action.bound
+  login(user, password){
+    return new Promise((resolve) => {
+      this.auth.login(user, password).then(response => {
+        this.currentUser = new UserStore(this);
+        this.currentUser.fetchData().then(() => resolve());
+        return response;
+      });
+    });
+  }
+
+  @action.bound
+  signOut(){
+    this.currentUser = null;
+  }
+
+  @action.bound
+  autologin(){
+    return new Promise((resolve, reject) => {
+      this.auth.autologin().then(response => {
+        if(response !== null){
+          console.log('token refreshed...');
+          this.currentUser = new UserStore(this);
+          this.currentUser.fetchData()
+            .then(() => resolve(response), () => { reject(response) })
+            .catch((err) => { reject(err); });
         }
-        resolve(this.createAxiosInstance());
-      }
+        else{
+          reject(response)
+        }
+      })
     });
   }
 
   @action.bound
   get(url){
     return this.getAxiosInstance().then(instance => instance.get(`${API_HOSTNAME}${url}`));
-  }
-
-  @computed get tokenValidIat(){
-    // checks if token is refreshable - maybe it is too late for it to be refreshed?
-    console.log('seconds since refresh: ', new Date().getTime() - this.token_iat );
-    return this.token_iat !== undefined && new Date().getTime() < this.token_iat + TOKEN_EXPIRATION_DELTA;
-  }
-
-  @computed get tokenValidOrigIat(){
-    // checks if tokens can still be refreshed against origin token picking time
-    console.log('orig_iat seconds since start: ', new Date().getTime() - this.token_original_iat );
-    return this.token_original_iat !== undefined && new Date().getTime() < this.token_original_iat + TOKEN_REFRESH_EXPIRATION;
-  }
-
-  @computed get tokenShouldRefresh(){
-    // checks if enough time has passed for the token to be refreshed
-    console.log('iat seconds since start to refresh rate: ', new Date().getTime() - this.token_iat , this.token_iat + TOKEN_REFRESH_RATE);
-    return this.token_iat !== undefined && new Date().getTime() > this.token_iat + TOKEN_REFRESH_RATE;
-  }
-
-  resetToken(){
-    this.token_iat = new Date().getTime();
-  }
-
-  hardResetToken(){
-    this.token_iat = this.token_original_iat = new Date().getTime();
-  }
-
-  @action
-  isAuthenticated(){
-    if(this.currentUser)
-      // console.log(this, this.token !== undefined && this.tokenValidIat && this.currentUser && this.currentUser.profileID !== undefined);
-    return this.token !== undefined && this.tokenValidIat && this.currentUser && this.currentUser.profileID !== undefined;
-  }
-
-  @action refreshToken() {
-    return axiosInstance.post(`${API_HOSTNAME}/token/refresh/`, {'token': this.token, 'orig_iat': this.token_original_iat}).then(response => {
-      this.token = response.data.token;
-      this.resetToken();
-      console.log('refreshing token to: ', this.token);
-    })
-      .catch((e) => {
-        console.log('Failed to refresh... ', e.response);
-        this.signOut();
-        //window.location.reload();
-      });
-  }
-
-  @action.bound
-  login(user, password){
-    return new Promise((resolve, reject) => {
-      axiosInstance.post(`${API_HOSTNAME}/token/auth/`, {
-        'username': user,
-        'password': password,
-      }).then((response) => {
-        console.log(response.data);
-        if (response.status === 200) {
-          this.token = response.data.token;
-          this.hardResetToken();
-
-          this.currentUser = new UserStore(this);
-          this.currentUser.fetchData().then(() => resolve());
-        }
-      });
-    });
-
-
-  }
-
-  @action.bound
-  signOut(){
-    this.token = undefined;
-    this.token_iat = undefined;
-    this.token_original_iat = undefined;
-    this.currentUser = null;
-  }
-
-
-  @action.bound
-  autologin(){
-    return new Promise((resolve, reject) => {
-      console.log('trying to log in automatically...');
-      if(this.token && new Date().getTime() < this.token_original_iat + TOKEN_EXPIRATION_DELTA){
-        // refresh token
-        console.log('refreshing token on autologin...');
-        this.refreshToken().then(() => {
-          console.log('token refreshed...');
-          this.currentUser = new UserStore(this);
-          this.currentUser.fetchData()
-            .then(() => resolve(), () => { reject() })
-            .catch((err) => { reject(err); });
-        });
-      }
-      else{
-        reject();
-        this.signOut();
-      }
-    });
   }
 
   @action.bound
@@ -302,70 +146,3 @@ export class PortalStore {
   }
 }
 
-
-export class NavigationStore {
-  @observable rootStore;
-  @observable drawerStatus = false;
-
-  constructor(rootStore) {
-    this.rootStore = rootStore;
-  }
-
-  @action.bound
-  toggleDrawer(){
-    this.drawerStatus = !this.drawerStatus;
-  }
-}
-
-
-export class UserStore {
-  @observable rootStore;
-  profileID;
-  userID;
-  @observable first_name;
-  @observable last_name;
-  @observable nickname;
-  @observable dci;
-  role;
-  @observable charactersCount;
-
-  constructor(rootStore) {
-    this.rootStore = rootStore;
-  }
-
-  @computed get isDM(){
-    return this.role === 'Dungeon Master';
-  }
-
-  @action.bound
-  fetchData(){
-    return this.rootStore.get(`/current_user/`)
-      .then((response) => {
-        const data = response.data;
-        this.profileID = data.id;
-        this.userID = data.user.id;
-        this.first_name = data.user.first_name;
-        this.last_name = data.user.last_name;
-        this.nickname = data.nickname;
-        this.dci = data.dci;
-        this.role = data.role;
-        this.charactersCount = data.characters_count;
-      })
-      .catch((err) => {
-        this.rootStore.signOut();
-      });
-  }
-
-  @action.bound
-  saveData(){
-    return this.rootStore.getAxiosInstance().then(instance => instance.put(`${API_HOSTNAME}/profiles/${this.profileID}/`,
-      {
-        'id': this.profileID,
-        'user': this.userID,
-        'nickname': this.nickname,
-        'dci': this.dci,
-    }).catch((err) => {
-      this.rootStore.signOut();
-    }));
-  }
-}

--- a/front/src/store.js
+++ b/front/src/store.js
@@ -2,8 +2,7 @@ import {action, observable} from 'mobx';
 import {API_HOSTNAME} from "./config";
 import GamesStore from "./stores/GamesStore";
 import AdventuresStore from "./stores/AdventuresStore";
-import TokenAuthorizationStore from "./stores/TokenAuthorizationStore";
-import {AxiosInstance as axiosInstance} from "axios";
+import TokenAuthorizationStore, {axiosInstance} from "./stores/TokenAuthorizationStore";
 import UserStore from "./stores/UserStore";
 import NavigationStore from "./stores/NavigationStore";
 import Api from "./api";
@@ -67,17 +66,14 @@ export class PortalStore {
     }
   }
 
-  @action.bound
   register(data){
     return axiosInstance.post(`${API_HOSTNAME}/register/`, data)
   }
 
-  @action.bound
   sendPasswordReset(login){
     return axiosInstance.post(`${API_HOSTNAME}/password_reset/`, {email: login})
   }
 
-  @action.bound
   changePassword(token, password){
     return axiosInstance.post(`${API_HOSTNAME}/password_reset/confirm/`, {token: token, password: password});
   };

--- a/front/src/stores/AdventuresStore.js
+++ b/front/src/stores/AdventuresStore.js
@@ -1,5 +1,5 @@
 import {Game} from "./GamesStore";
-import {observable} from "mobx";
+import {computed, observable} from "mobx";
 
 
 export default class AdventuresStore {
@@ -9,8 +9,12 @@ export default class AdventuresStore {
     this.root = rootStore;
   }
 
+  @computed get api(){
+    return this.root.api;
+  }
+
   fetch(){
     this.items = [];
-    return this.root.fetchData('adventures');
+    return this.api.fetchData('adventures');
   }
 }

--- a/front/src/stores/ApiStore.js
+++ b/front/src/stores/ApiStore.js
@@ -1,5 +1,0 @@
-
-
-export default class ApiStore {
-
-}

--- a/front/src/stores/ApiStore.js
+++ b/front/src/stores/ApiStore.js
@@ -1,0 +1,5 @@
+
+
+export default class ApiStore {
+
+}

--- a/front/src/stores/GamesStore.js
+++ b/front/src/stores/GamesStore.js
@@ -1,35 +1,40 @@
-import {observable} from 'mobx';
+import {computed, observable} from 'mobx';
 import {dateToString, weekdayOf} from "../utils";
+import Api from "../api";
 
 export default class GamesStore {
   @observable root = null;
 
   constructor(root){
-    this.root = root
+    this.root = root;
+  }
+
+  @computed get api(){
+    return this.root.api;
   }
 
   fetch(){
-    return this.root.fetchData('games/list');
+    return this.api.fetchData('games/list');
   }
 
   fetchFuture(){
-    return this.root.fetchData('games/future');
+    return this.api.fetchData('games/future');
   }
 
   fetchPast(){
-    return this.root.fetchData('games/past');
+    return this.api.fetchData('games/past');
   }
 
   fetchFutureForUser(id){
-    return this.root.get(`/games/future/?having_player=${id}`).then(response => response.data);
+    return this.api.get(`/games/future/?having_player=${id}`).then(response => response.data);
   }
 
   fetchFutureForDM(id){
-    return this.root.get(`/games/future/?dm__id=${id}`).then(response => response.data);
+    return this.api.get(`/games/future/?dm__id=${id}`).then(response => response.data);
   }
 
   fetchNotReportedForDM(id){
-    return this.root.get(`/games/past/?dm__id=${id}&reported=false`).then(response => response.data);
+    return this.api.get(`/games/past/?dm__id=${id}&reported=false`).then(response => response.data);
   }
 
   fetchFutureForCurrentUser(){
@@ -45,27 +50,27 @@ export default class GamesStore {
   }
 
   get(id){
-    return this.root.getData('games/list', id);
+    return this.api.getData('games/list', id);
   }
 
   book(id, data){
-    return this.root.putData('games/booking', id, data);
+    return this.api.putData('games/booking', id, data);
   }
 
   cancel(id){
-    return this.root.get(`/games/booking/${id}/cancel/`);
+    return this.api.get(`/games/booking/${id}/cancel/`);
   }
 
   signUp(id, characterId){
-    return this.root.putData('games/list', `${id}/signUp`, {character_id: characterId})
+    return this.api.putData('games/list', `${id}/signUp`, {character_id: characterId})
   }
 
   signOut(id){
-    return this.root.putData('games/list', `${id}/signOut`, {})
+    return this.api.putData('games/list', `${id}/signOut`, {})
   }
 
   sendReport(id, data){
-    return this.root.putData('games/list', `${id}/report`, data)
+    return this.api.putData('games/list', `${id}/report`, data)
   }
 
   static getDMName(game) {

--- a/front/src/stores/NavigationStore.js
+++ b/front/src/stores/NavigationStore.js
@@ -1,0 +1,15 @@
+import {action, observable} from "mobx";
+
+export default class NavigationStore {
+  @observable rootStore;
+  @observable drawerStatus = false;
+
+  constructor(rootStore) {
+    this.rootStore = rootStore;
+  }
+
+  @action.bound
+  toggleDrawer(){
+    this.drawerStatus = !this.drawerStatus;
+  }
+}

--- a/front/src/stores/TokenAuthorizationStore.js
+++ b/front/src/stores/TokenAuthorizationStore.js
@@ -1,0 +1,191 @@
+import Cookies from "js-cookie";
+import axios from "axios";
+import {action, computed, observable, reaction} from "mobx";
+import {
+  JWT_TOKEN,
+  JWT_TOKEN_IAT,
+  JWT_TOKEN_ORIG_IAT,
+  TOKEN_EXPIRATION_DELTA,
+  TOKEN_REFRESH_EXPIRATION, TOKEN_REFRESH_RATE
+} from "../constants";
+import {API_HOSTNAME} from "../config";
+
+const csrftoken = Cookies.get('csrftoken');
+
+
+export const axiosInstance = axios.create({
+  headers: {
+    'X-CSRFToken': csrftoken,
+  }
+});
+
+
+export default class TokenAuthorizationStore {
+  @observable root = null;
+  @observable token = window.localStorage.getItem(JWT_TOKEN);
+  @observable token_iat = window.localStorage.getItem(JWT_TOKEN_IAT);
+  @observable token_original_iat = window.localStorage.getItem('jwt_orig_iat');
+
+  constructor(root) {
+    this.root = root;
+
+    reaction(
+      () => this.token,
+      token => {
+        if (token){
+          window.localStorage.setItem(JWT_TOKEN, token);
+        } else {
+          window.localStorage.removeItem(JWT_TOKEN);
+        }
+      }
+    );
+
+    reaction(
+      () => this.token_iat,
+      token_iat => {
+        if (token_iat) {
+          window.localStorage.setItem(JWT_TOKEN_IAT, token_iat);
+        } else {
+          window.localStorage.removeItem(JWT_TOKEN_IAT);
+        }
+      }
+    );
+
+    reaction(
+      () => this.token_original_iat,
+      token_iat => {
+        if (token_iat) {
+          window.localStorage.setItem(JWT_TOKEN_ORIG_IAT, token_iat);
+        } else {
+          window.localStorage.removeItem(JWT_TOKEN_ORIG_IAT);
+        }
+      }
+    );
+  }
+
+  @computed get tokenValidIat(){
+    // checks if token is refreshable - maybe it is too late for it to be refreshed?
+    console.log('seconds since refresh: ', new Date().getTime() - this.token_iat );
+    return this.token_iat !== undefined && new Date().getTime() < this.token_iat + TOKEN_EXPIRATION_DELTA;
+  }
+
+  @computed get tokenValidOrigIat(){
+    // checks if tokens can still be refreshed against origin token picking time
+    console.log('orig_iat seconds since start: ', new Date().getTime() - this.token_original_iat );
+    return this.token_original_iat !== undefined && new Date().getTime() < this.token_original_iat + TOKEN_REFRESH_EXPIRATION;
+  }
+
+  @computed get tokenShouldRefresh(){
+    // checks if enough time has passed for the token to be refreshed
+    console.log('iat seconds since start to refresh rate: ', new Date().getTime() - this.token_iat , this.token_iat + TOKEN_REFRESH_RATE);
+    return this.token_iat !== undefined && new Date().getTime() > this.token_iat + TOKEN_REFRESH_RATE;
+  }
+
+  resetToken(){
+    this.token_iat = new Date().getTime();
+  }
+
+  hardResetToken(){
+    this.token_iat = this.token_original_iat = new Date().getTime();
+  }
+
+  @action
+  isAuthenticated(){
+    return this.token !== undefined && this.tokenValidIat;
+  }
+
+  @action refreshToken() {
+    return axiosInstance.post(`${API_HOSTNAME}/token/refresh/`, {'token': this.token, 'orig_iat': this.token_original_iat}).then(response => {
+      this.token = response.data.token;
+      this.resetToken();
+      console.log('refreshing token to: ', this.token);
+      return response;
+    })
+      .catch((e) => {
+        console.log('Failed to refresh... ', e.response);
+        this.signOut();
+        //window.location.reload();
+      });
+  }
+
+  createAxiosInstance() {
+    const instance = axios.create({
+      headers: {
+        'X-CSRFToken': Cookies.get('csrftoken'),
+        'Authorization': `JWT ${this.token}`
+      }
+    });
+
+    instance.interceptors.response.use(response => {
+       return response;
+    }, error => {
+      if (error.response.status === 401) {
+        console.log('Tokens have expired! Need to sign in again');
+        this.signOut();
+        window.location.reload();
+      }
+      return error;
+    });
+
+    return instance;
+  }
+
+  getAxiosInstance(){
+    return new Promise((resolve) => {
+      console.log('loading...', this.token_iat);
+      if(this.tokenShouldRefresh && this.tokenValidIat){
+        console.log('refreshing token!', this.token_iat);
+
+        this.refreshToken().then(() => {
+          resolve(this.createAxiosInstance());
+        }).catch(e => {
+          console.log('Looks like there was an issue with retrieving token data. Resetting state to login.', e);
+          this.signOut();
+          window.location.reload();
+        });
+      }
+      else {
+        if (!this.tokenValidOrigIat) {
+          console.log('Expired refresh! Cannot get any new token until user signs in');
+          this.signOut();
+          window.location.reload();
+        }
+        resolve(this.createAxiosInstance());
+      }
+    });
+  }
+
+  login(user, password){
+    return axiosInstance.post(`${API_HOSTNAME}/token/auth/`, {
+      'username': user,
+      'password': password,
+    }).then((response) => {
+      console.log(response.data);
+      if (response.status === 200) {
+        this.token = response.data.token;
+        this.hardResetToken();
+      }
+      return response;
+    });
+  }
+
+  signOut(){
+    this.token = undefined;
+    this.token_iat = undefined;
+    this.token_original_iat = undefined;
+    // FIXME: should be independent from the root store
+    this.root.signOut();
+  }
+
+  @action.bound
+  autologin(){
+    if(this.token && new Date().getTime() < this.token_original_iat + TOKEN_EXPIRATION_DELTA){
+      // refresh token
+      console.log('refreshing token on autologin...');
+      return this.refreshToken();
+    }
+    else{
+      return null;
+    }
+  }
+}

--- a/front/src/stores/UserStore.js
+++ b/front/src/stores/UserStore.js
@@ -1,0 +1,54 @@
+import {action, computed, observable} from "mobx";
+import {API_HOSTNAME} from "../config";
+
+export default class UserStore {
+  @observable rootStore;
+  profileID;
+  userID;
+  @observable first_name;
+  @observable last_name;
+  @observable nickname;
+  @observable dci;
+  role;
+  @observable charactersCount;
+
+  constructor(rootStore) {
+    this.rootStore = rootStore;
+  }
+
+  @computed get isDM(){
+    return this.role === 'Dungeon Master';
+  }
+
+  @action.bound
+  fetchData(){
+    return this.rootStore.get(`/current_user/`)
+      .then((response) => {
+        const data = response.data;
+        this.profileID = data.id;
+        this.userID = data.user.id;
+        this.first_name = data.user.first_name;
+        this.last_name = data.user.last_name;
+        this.nickname = data.nickname;
+        this.dci = data.dci;
+        this.role = data.role;
+        this.charactersCount = data.characters_count;
+      })
+      .catch((err) => {
+        this.rootStore.signOut();
+      });
+  }
+
+  @action.bound
+  saveData(){
+    return this.rootStore.getAxiosInstance().then(instance => instance.put(`${API_HOSTNAME}/profiles/${this.profileID}/`,
+      {
+        'id': this.profileID,
+        'user': this.userID,
+        'nickname': this.nickname,
+        'dci': this.dci,
+    }).catch((err) => {
+      this.rootStore.signOut();
+    }));
+  }
+}

--- a/front/src/stores/UserStore.js
+++ b/front/src/stores/UserStore.js
@@ -2,7 +2,7 @@ import {action, computed, observable} from "mobx";
 import {API_HOSTNAME} from "../config";
 
 export default class UserStore {
-  @observable rootStore;
+  @observable root;
   profileID;
   userID;
   @observable first_name;
@@ -12,8 +12,12 @@ export default class UserStore {
   role;
   @observable charactersCount;
 
-  constructor(rootStore) {
-    this.rootStore = rootStore;
+  constructor(root) {
+    this.root = root;
+  }
+
+  @computed get api(){
+    return this.root.api;
   }
 
   @computed get isDM(){
@@ -22,7 +26,7 @@ export default class UserStore {
 
   @action.bound
   fetchData(){
-    return this.rootStore.get(`/current_user/`)
+    return this.root.api.get(`/current_user/`)
       .then((response) => {
         const data = response.data;
         this.profileID = data.id;
@@ -35,20 +39,20 @@ export default class UserStore {
         this.charactersCount = data.characters_count;
       })
       .catch((err) => {
-        this.rootStore.signOut();
+        this.root.signOut();
       });
   }
 
   @action.bound
   saveData(){
-    return this.rootStore.getAxiosInstance().then(instance => instance.put(`${API_HOSTNAME}/profiles/${this.profileID}/`,
+    return this.api.put(`/profiles/${this.profileID}/`,
       {
         'id': this.profileID,
         'user': this.userID,
         'nickname': this.nickname,
         'dci': this.dci,
     }).catch((err) => {
-      this.rootStore.signOut();
-    }));
+      this.root.signOut();
+    });
   }
 }

--- a/front/src/stores/UserStore.js
+++ b/front/src/stores/UserStore.js
@@ -45,10 +45,13 @@ export default class UserStore {
 
   @action.bound
   saveData(){
-    return this.api.put(`/profiles/${this.profileID}/`,
+    return this.api.put(`/current_user/`,
       {
         'id': this.profileID,
-        'user': this.userID,
+        'user': {
+          'first_name': this.first_name,
+          'last_name': this.last_name,
+        },
         'nickname': this.nickname,
         'dci': this.dci,
     }).catch((err) => {

--- a/profiles/api/serializers.py
+++ b/profiles/api/serializers.py
@@ -68,7 +68,9 @@ class ProfileSerializer(serializers.ModelSerializer):
             instance.nickname = validated_data.get('nickname', instance.nickname)
             instance.save()
 
-            UserSerializer().update(instance=instance.user, validated_data=user_data)
+            user_serializer = UserSerializer(instance=instance.user, data=user_data)
+            if user_serializer.is_valid():
+                user_serializer.save()
 
         return instance
 

--- a/profiles/api/serializers.py
+++ b/profiles/api/serializers.py
@@ -120,7 +120,7 @@ class RegisterUserSerializer(serializers.ModelSerializer):
 
 class RegisterProfileSerializer(serializers.ModelSerializer):
     user = RegisterUserSerializer(required=True)
-    dci = serializers.IntegerField(required=False)
+    dci = serializers.IntegerField(required=False, allow_null=True)
 
     class Meta:
         model = Profile

--- a/profiles/api/views.py
+++ b/profiles/api/views.py
@@ -1,4 +1,3 @@
-from rest_framework import viewsets, mixins, status
 from django_filters import rest_framework as filters
 from rest_framework import viewsets, mixins, status
 from rest_framework.filters import SearchFilter, OrderingFilter
@@ -47,8 +46,7 @@ class DMNoteViewSet(viewsets.ModelViewSet):
         serializer.save(dm=self.request.user.profile)
 
 
-class ProfileViewSet(mixins.UpdateModelMixin,
-                     mixins.RetrieveModelMixin,
+class ProfileViewSet(mixins.RetrieveModelMixin,
                      mixins.ListModelMixin,
                      viewsets.GenericViewSet):
     serializer_class = PublicProfileSerializer
@@ -60,6 +58,12 @@ class ProfileViewSet(mixins.UpdateModelMixin,
 class CurrentUserView(APIView):
     def get(self, request):
         serializer = ProfileSerializer(request.user.profile)
+        return Response(serializer.data)
+
+    def put(self, request):
+        serializer = ProfileSerializer(request.user.profile, data=request.data)
+        if serializer.is_valid():
+            serializer.save()
         return Response(serializer.data)
 
 

--- a/settings/base.py
+++ b/settings/base.py
@@ -141,7 +141,9 @@ REST_FRAMEWORK = {
 }
 
 JWT_AUTH = {
-    'JWT_EXPIRATION_DELTA': datetime.timedelta(hours=1),
+    'JWT_EXPIRATION_DELTA': datetime.timedelta(hours=48),
+    'JWT_REFRESH_EXPIRATION_DELTA': datetime.timedelta(days=7),
+    'JWT_ALLOW_REFRESH': True,
 }
 
 EMAIL_HOST = 'localhost'


### PR DESCRIPTION
Big changes to use of JWT token authorization mechanizm. Token can be refreshed to prolongate authorization. This has some impact on most of the react code deeper.

Closes #96

**TODO**
  - [x] move authorization parts to a separate store that works on tokens only
  - [x] cleanup `console.log` parts
  - [x] ~~try to use refresh for JWT plugin that allows refresh after expiration~~