### PR TITLE
Use get_queryset for proper pulling future games

### DIFF
--- a/games/api/views.py
+++ b/games/api/views.py
@@ -103,11 +103,13 @@ class GameSessionViewSet(mixins.ListModelMixin,
 
 
 class FutureGameSessionViewSet(GameSessionViewSet):
-    queryset = GameSession.games.future()
+    def get_queryset(self):
+        return GameSession.games.future()
 
 
 class PastGameSessionViewSet(GameSessionViewSet):
-    queryset = GameSession.games.past().exclude(adventure=None)
+    def get_queryset(self):
+        return GameSession.games.past().exclude(adventure=None)
 
 
 class GameSessionBookViewSet(mixins.UpdateModelMixin,


### PR DESCRIPTION
This should fix issue with previous games showing up in the future list. DRF does some API caches of queryset at first run and does not call DB again instead.

According to DRF docs:
> `queryset` - The queryset that should be used for returning objects from this view. Typically, you must either set this attribute, or override the `get_queryset()` method. If you are overriding a view method, it is important that you call `get_queryset()` instead of accessing this property directly, as queryset will get evaluated once, and those results will be cached for all subsequent requests.

Source: https://www.django-rest-framework.org/api-guide/generic-views/#attributes