### PR TITLE
maint: migrating the project to python 3.11 and upgrading packages

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -4,7 +4,7 @@ services:
   backend:
     volumes:
       - ./backend:/code
-      - pip:/usr/local/lib/python3.7/site-packages
+      - pip:/usr/local/lib/python3.11/site-packages
     command: devel_web
     ports:
       - "8000:8000"
@@ -22,8 +22,8 @@ services:
     ports:
       - "3000:3000"
   email:
-    image: python:3.7
-    command: python -m smtpd -n -c DebuggingServer 0.0.0.0:1025
+    image: python:3.11
+    command: sh -c "pip install aiosmtpd -q && python -m aiosmtpd -n -l 0.0.0.0:1025"
 
 volumes:
   pip:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,11 @@ services:
       context: ./frontend
     command: npm run build_prod
   db:
-    image: postgres:10.1-alpine
+    image: postgres:17-alpine
+    environment:
+      POSTGRES_DB: postgres
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
     volumes:
       - postgres_data:/var/lib/postgresql/data/
 


### PR DESCRIPTION
- Updated site-packages paths to 3.11
- PostgreSQL: 10.1 → 17-alpine
- Fixed email service: smtpd → aiosmtpd for Python 3.11+
- Added POSTGRES_PASSWORD env var
