### PR TITLE
feat: Pagination for Games Archive list

### DIFF
--- a/backend/games/api/__tests__/test_views.py
+++ b/backend/games/api/__tests__/test_views.py
@@ -210,4 +210,62 @@ class TestPastGameSessionViewSet:
         response = client.get("/api/games/past/")
 
         assert response.status_code == 200
-        assert len(response.data) == 1
+        assert len(response.data["results"]) == 1
+
+    def test_pagination_structure(self, game_session_factory, user_factory, profile_factory, adventure_factory):
+        adventure = adventure_factory()
+        game_session_factory.create_batch(
+            3, active=True, date=timezone.now().date() - timezone.timedelta(days=2), adventure=adventure
+        )
+
+        user = user_factory()
+        profile_factory(user=user)
+        client = APIClient()
+        client.force_authenticate(user=user)
+        response = client.get("/api/games/past/")
+
+        assert response.status_code == 200
+        assert "count" in response.data
+        assert "next" in response.data
+        assert "previous" in response.data
+        assert "results" in response.data
+        assert response.data["count"] == 3
+        assert response.data["next"] is None
+        assert response.data["previous"] is None
+        assert len(response.data["results"]) == 3
+
+    def test_pagination_limit_param(self, game_session_factory, user_factory, profile_factory, adventure_factory):
+        adventure = adventure_factory()
+        game_session_factory.create_batch(
+            5, active=True, date=timezone.now().date() - timezone.timedelta(days=2), adventure=adventure
+        )
+
+        user = user_factory()
+        profile_factory(user=user)
+        client = APIClient()
+        client.force_authenticate(user=user)
+        response = client.get("/api/games/past/?limit=2")
+
+        assert response.status_code == 200
+        assert response.data["count"] == 5
+        assert len(response.data["results"]) == 2
+        assert response.data["next"] is not None
+        assert response.data["previous"] is None
+
+    def test_pagination_offset_param(self, game_session_factory, user_factory, profile_factory, adventure_factory):
+        adventure = adventure_factory()
+        game_session_factory.create_batch(
+            5, active=True, date=timezone.now().date() - timezone.timedelta(days=2), adventure=adventure
+        )
+
+        user = user_factory()
+        profile_factory(user=user)
+        client = APIClient()
+        client.force_authenticate(user=user)
+        response = client.get("/api/games/past/?offset=2")
+
+        assert response.status_code == 200
+        assert response.data["count"] == 5
+        assert len(response.data["results"]) == 3
+        assert response.data["next"] is None
+        assert response.data["previous"] is not None

--- a/backend/games/api/views.py
+++ b/backend/games/api/views.py
@@ -1,5 +1,5 @@
 from django_filters import rest_framework as filters
-from rest_framework import mixins, status, viewsets
+from rest_framework import mixins, pagination, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.filters import OrderingFilter, SearchFilter
 from rest_framework.permissions import IsAuthenticated
@@ -34,6 +34,7 @@ class GameSessionViewSet(
     search_fields = ("table__name", "dm__user__first_name", "dm__user__last_name", "dm__nickname", "adventure__title")
     ordering_fields = ("date", "time_end", "time_start")
     ordering = "date"
+    pagination_class = None
 
     @action(methods=["PUT"], detail=True)
     def signUp(self, request, *args, **kwargs):
@@ -93,13 +94,26 @@ class GameSessionViewSet(
 
 
 class FutureGameSessionViewSet(GameSessionViewSet):
+    pagination_class = None
+
     def get_queryset(self):
         return GameSession.games.future()
 
 
 class PastGameSessionViewSet(GameSessionViewSet):
+    pagination_class = pagination.LimitOffsetPagination
+
     def get_queryset(self):
         return GameSession.games.past().exclude(adventure=None)
+
+    def list(self, request, *args, **kwargs):
+        queryset = self.filter_queryset(self.get_queryset())
+        page = self.paginate_queryset(queryset)
+        if page is not None:
+            serializer = self.get_serializer(page, many=True)
+            return self.get_paginated_response(serializer.data)
+        serializer = self.get_serializer(queryset, many=True)
+        return Response(serializer.data)
 
 
 class GameSessionBookViewSet(mixins.UpdateModelMixin, viewsets.GenericViewSet):

--- a/backend/settings/base.py
+++ b/backend/settings/base.py
@@ -125,6 +125,7 @@ REST_FRAMEWORK = {
         "rest_framework.authentication.SessionAuthentication",
         "rest_framework.authentication.BasicAuthentication",
     ),
+    "PAGE_SIZE": 30,
 }
 
 SIMPLE_JWT = {

--- a/frontend/src/pages/GamesList.js
+++ b/frontend/src/pages/GamesList.js
@@ -8,6 +8,7 @@ import Link from "react-router-dom/es/Link";
 import Switch from "@material-ui/core/Switch/Switch";
 import FormGroup from "@material-ui/core/FormGroup/FormGroup";
 import FormControlLabel from "@material-ui/core/FormControlLabel/FormControlLabel";
+import Button from "@material-ui/core/Button/Button";
 import {BoolStorage} from "../common/PortalUtils"
 
 //upcoming games list /games
@@ -121,6 +122,13 @@ class PastGamesList extends React.Component {
     games: null,
     displayMyGames:     BoolStorage.get('selector_displayMyGames'),
     displayMyDMGames:   BoolStorage.get('selector_displayMyDMGames'),
+    pagination: {
+      count: 0,
+      next: null,
+      previous: null,
+      limit: 30,
+      offset: 0
+    }
   };
 
   common_selectors = {
@@ -128,7 +136,7 @@ class PastGamesList extends React.Component {
     'displayMyDMGames':['displayMyGames']
   }
 
-  fetchData = () => {
+  fetchData = (offset = 0) => {
     const user_id = this.props.portalStore.currentUser.profileID;
     let extraParams = ``;
     if(this.state.displayMyGames) {
@@ -137,11 +145,19 @@ class PastGamesList extends React.Component {
     if(this.state.displayMyDMGames) {
       extraParams += `dm__id=${user_id}&`
     }
+    const limit = this.state.pagination.limit;
     console.log('Update: ', this.state);
-    this.props.portalStore.games.fetchPast(extraParams).then((games) => {
+    this.props.portalStore.games.fetchPast(extraParams, limit, offset).then((response) => {
       this.setState({
-        games: games,
-        loading: false,
+        games: response.results,
+        pagination: {
+          count: response.count,
+          next: response.next,
+          previous: response.previous,
+          limit: limit,
+          offset: offset
+        },
+        loading: false
       })
     })
   };
@@ -150,14 +166,21 @@ class PastGamesList extends React.Component {
     this.setState({
       loading: true,
     });
-    this.fetchData();
+    this.fetchData(0);
   }
 
   handleChange = name => event => {
     var hash_of_state = {
       [name]: event.target.checked,
       loading: true,
-      games: null
+      games: null,
+      pagination: {
+        count: 0,
+        next: null,
+        previous: null,
+        limit: 30,
+        offset: 0
+      }
     };
     if (event.target.checked && this.common_selectors[name]) {
         for (var depend in this.common_selectors[name]) {
@@ -165,8 +188,48 @@ class PastGamesList extends React.Component {
             BoolStorage.set(this.common_selectors[name][depend],'selector',false)
         }
     }
-    this.setState(hash_of_state, () => this.fetchData());
+    this.setState(hash_of_state, () => this.fetchData(0));
     BoolStorage.set(name,'selector',event.target.checked);
+  };
+
+  handlePrevPage = () => {
+    if (this.state.pagination.previous) {
+      const urlParams = new URLSearchParams(this.state.pagination.previous.split('?')[1]);
+      const offset = parseInt(urlParams.get('offset')) || 0;
+      this.setState({loading: true, games: null}, () => this.fetchData(offset));
+    }
+  };
+
+  handleNextPage = () => {
+    if (this.state.pagination.next) {
+      const urlParams = new URLSearchParams(this.state.pagination.next.split('?')[1]);
+      const offset = parseInt(urlParams.get('offset')) || 0;
+      this.setState({loading: true, games: null}, () => this.fetchData(offset));
+    }
+  };
+
+  renderPaginationControls = () => {
+    const {count, next, previous, limit, offset} = this.state.pagination;
+    const startIndex = offset + 1;
+    const endIndex = Math.min(offset + limit, count);
+
+    if (count === 0) return null;
+
+    return (
+      <div style={{display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 16}}>
+        <Typography variant='body2' color='textSecondary'>
+          Showing {startIndex}-{endIndex} of {count} games
+        </Typography>
+<div style={{display: 'flex', gap: 8}}>
+          <Button onClick={this.handlePrevPage} disabled={!previous} variant={previous ? 'contained' : 'outlined'} size='small' color='primary'>
+            Previous
+          </Button>
+          <Button onClick={this.handleNextPage} disabled={!next} variant={next ? 'contained' : 'outlined'} size='small' color='primary'>
+            Next
+          </Button>
+        </div>
+      </div>
+    );
   };
 
   render(){
@@ -181,6 +244,7 @@ class PastGamesList extends React.Component {
           <Typography variant='h5' className={classes.header}>
             Games archive
           </Typography>
+          {this.renderPaginationControls()}
           <FormGroup row className={classes.listFilters}>
             <FormControlLabel
               control={
@@ -212,6 +276,7 @@ class PastGamesList extends React.Component {
             of the ended game as a player or cancel booking on the slot that you already run as a Dungeon Master.
           </Typography>
           <Games list={this.state.games} />
+          {this.renderPaginationControls()}
         </div>
       )
   }

--- a/frontend/src/stores/GamesStore.js
+++ b/frontend/src/stores/GamesStore.js
@@ -21,8 +21,11 @@ export default class GamesStore {
     return this.api.fetchData('games/future');
   }
 
-  fetchPast(extraParams){
-    return this.api.fetchData('games/past', `ordering=-date,-time_end,-time_end&${extraParams}`);
+  fetchPast(extraParams, limit, offset){
+    let params = `ordering=-date,-time_end,-time_end&${extraParams}`;
+    if (limit) params += `&limit=${limit}`;
+    if (offset !== undefined) params += `&offset=${offset}`;
+    return this.api.fetchData('games/past', params);
   }
 
   fetchFutureForUser(id){


### PR DESCRIPTION
Past games is a pretty long list of results after many years of running the site. It loads long time to load while most of the users want to see more recent results only. 

This feature introduces pagination of the Games Archive page to show only 30 games per page. 