### PR TITLE
fix(games): serialize session sign-ups to enforce spot limit

### DIFF
--- a/backend/games/api/views.py
+++ b/backend/games/api/views.py
@@ -3,6 +3,7 @@ from django_filters import rest_framework as filters
 from rest_framework import mixins, pagination, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.filters import OrderingFilter, SearchFilter
+from rest_framework.generics import get_object_or_404
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
@@ -39,7 +40,6 @@ class GameSessionViewSet(
 
     @action(methods=["PUT"], detail=True)
     def signUp(self, request, *args, **kwargs):
-        instance = self.get_object()
         profile = request.user.profile
         try:
             character_id = request.data["character_id"]
@@ -51,7 +51,7 @@ class GameSessionViewSet(
             return Response(status=status.HTTP_400_BAD_REQUEST)
 
         with transaction.atomic():
-            instance = self.get_queryset().select_for_update().get(pk=instance.pk)
+            instance = get_object_or_404(self.get_queryset().select_for_update(), pk=self.kwargs["pk"])
 
             if not instance.can_sign_up(profile):
                 return Response(status=status.HTTP_400_BAD_REQUEST)

--- a/backend/games/api/views.py
+++ b/backend/games/api/views.py
@@ -1,3 +1,4 @@
+from django.db import transaction
 from django_filters import rest_framework as filters
 from rest_framework import mixins, pagination, status, viewsets
 from rest_framework.decorators import action
@@ -46,15 +47,18 @@ class GameSessionViewSet(
         except (PlayerCharacter.DoesNotExist, KeyError):
             return Response(status=status.HTTP_400_BAD_REQUEST)
 
-        if not instance.can_sign_up(profile):
-            return Response(status=status.HTTP_400_BAD_REQUEST)
-
         if character.dead:
             return Response(status=status.HTTP_400_BAD_REQUEST)
 
-        signup, _ = GameSessionPlayerSignUp.objects.get_or_create(game=instance, player=profile)
-        signup.character = character
-        signup.save(update_fields=["character"])
+        with transaction.atomic():
+            instance = self.get_queryset().select_for_update().get(pk=instance.pk)
+
+            if not instance.can_sign_up(profile):
+                return Response(status=status.HTTP_400_BAD_REQUEST)
+
+            signup, _ = GameSessionPlayerSignUp.objects.get_or_create(game=instance, player=profile)
+            signup.character = character
+            signup.save(update_fields=["character"])
 
         return Response()
 


### PR DESCRIPTION
## Summary

Concurrent sign-ups can exceed a session's `spots` limit (e.g. more than 5 players on a 5-spot game). The `signUp` action does a **check-then-act** with no synchronization:

1. `instance.can_sign_up(profile)` reads `players.count() < spots`
2. `GameSessionPlayerSignUp.objects.get_or_create(...)` inserts

Two requests that arrive while a spot is free both pass step 1 and both insert at step 2, overflowing the limit. There is no transaction or row lock, and the limit is a row-count invariant that can't be enforced by a column constraint.

## Fix

Treat `GameSession` as the aggregate root and serialize sign-ups through it. Inside `transaction.atomic()`, re-fetch the session with `select_for_update()` to take a row lock, then run the capacity check and the insert under that lock. Concurrent sign-ups for the same session now serialize: the second request waits, re-reads the now-full count, and is rejected by `can_sign_up`.

Notes:
- Pessimistic locking fits this low-contention path and needs no schema change. On Postgres (docker/prod) `select_for_update()` takes a real row lock; on SQLite (tests) it is a harmless no-op and SQLite already serializes writers.
- Character validation (`character.dead`) was moved ahead of the locked block so the lock only spans the capacity check and insert.

## Scope

This PR fixes **only** the capacity-overflow race. The separate duplicate-sign-up issue (a player signing up twice, caused by `get_or_create` not being atomic without a `UniqueConstraint` on `(game, player)`) is **not** addressed here.

## Test plan

- [ ] Existing `games` suite passes (`pytest games/`), including `TestGameSessionSignUp` — confirms the refactor preserves happy-path, dead-character, and full-game behavior.
- [ ] Eyeball: on Postgres, two simultaneous sign-ups to the last spot result in one 200 and one 400.